### PR TITLE
Refactor to use "named readtables"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Common Lisp is amazing, but unfortunately sometimes libraries are not present th
 ```lisp
 (in-package :clsh-user)
 
-(enable-var-reader)
+(in-readtable :clsh-syntax)
 
 ;; outputs "hello world"
 (with-programs ("echo")

--- a/clsh-addons.lisp
+++ b/clsh-addons.lisp
@@ -1,31 +1,13 @@
 (in-package :clsh-addons)
 
-(defvar *dispatch-table* (make-hash-table :test 'equal))
+(defun read-env-variable (stream char)
+  (declare (ignore char))
+  `(environment-variable
+    ,(let ((*readtable* (copy-readtable)))
+       (setf (readtable-case *readtable*) :preserve)
+       (SYMBOL-NAME (READ STREAM)))))
 
-(defun enable-var-reader ()
-  (let ((readtable (copy-readtable)))
-  (set-macro-character #\$
-                       #'(lambda (stream char)
-                           (declare (ignore char))
-                           `(environment-variable
-                             ,(let ((*readtable*
-                                      (copy-readtable readtable)))
-                                (setf (readtable-case *readtable*)
-                                      :preserve)
-                                (SYMBOL-NAME (READ STREAM))))))))
 
-(defun enable-carrot-reader ()
-  (set-macro-character #\^
-                       #'(lambda (stream char)
-                           (declare (ignore char))
-                           (let* ((next (read-char stream))
-                                  (dispatch-fn (gethash next
-                                                        *dispatch-table*)))
-                             (unless dispatch-fn
-                               (error "Error: no macro defined for ~s"
-                                      next))
-                             (funcall dispatch-fn next stream)))))
-
-(defun set-carrot-macro (char macro-fn)
-  (setf (gethash char *dispatch-table*) macro-fn))
-
+(defreadtable :clsh-syntax
+  (:merge :standard)
+  (:macro-char #\$ #'read-env-variable))

--- a/clsh.asd
+++ b/clsh.asd
@@ -13,6 +13,7 @@
   :description "Provides the ability to run and compose UNIX programs"
   :serial t
   :depends-on ("cffi"
+               "named-readtables"
                "split-sequence"
                "trivial-gray-streams"
                "osicat")

--- a/defpackage.lisp
+++ b/defpackage.lisp
@@ -39,6 +39,7 @@
 
 (defpackage :clsh-addons
   (:use :cl
+        :named-readtables
         :osicat
         :utils)
   (:export enable-var-reader))
@@ -47,4 +48,5 @@
   (:use :cl
         :clsh-addons
         :clexec
+        :named-readtables
         :osicat))

--- a/example.lisp
+++ b/example.lisp
@@ -1,6 +1,6 @@
 (in-package :clsh-user)
 
-(enable-var-reader)
+(in-readtable :clsh-syntax)
 
 ;; lists the contents of the directory and outputs to *standard-output*
 (with-programs ("ls")
@@ -23,3 +23,4 @@
 (with-programs ("echo")
   (to *standard-output*
       (echo :arguments (list $MY_ENV_VAR))))
+

--- a/quicklisp.lisp
+++ b/quicklisp.lisp
@@ -2,3 +2,4 @@
 (ql:quickload :split-sequence)
 (ql:quickload :trivial-gray-streams)
 (ql:quickload :osicat)
+(ql:quickload :named-readtables)


### PR DESCRIPTION
Named readtables make it easier for users (and maintainers) to use the custom "$" syntax for environment variable access. 

Also generally improved the behavior of `unix-streams` read functionality. 